### PR TITLE
Fixed the docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "25519:25519"
     volumes:
-      - ./server/uploads:/app/server/uploads
+      - uploads_volume:/app/server/uploads
       - ./server/.env:/app/server/.env  # 挂载 .env 文件以持久化 JWT_SECRET
     depends_on:
       mongodb:
@@ -46,3 +46,4 @@ networks:
 
 volumes:
   mongodb_data: 
+  uploads_volume: 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复 docker-compose 配置，将上传目录切换到命名的 Docker 卷

杂务：
- 将服务器上传的主机绑定挂载替换为命名的卷
- 在 volumes 部分声明 uploads_volume

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix docker-compose configuration by switching the uploads directory to a named Docker volume

Chores:
- Replace host bind mount for server uploads with a named volume
- Declare uploads_volume under the volumes section

</details>