### PR TITLE
调整mongoose连接日志输出顺序

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -61,9 +61,9 @@ const connectDB = async () => {
         serverSelectionTimeoutMS: 5000, // 超时时间
         socketTimeoutMS: 45000, // Socket 超时时间
       })
-      console.log('MongoDB数据库连接成功')
       // 初始化配置
       await Config.initialize()
+      console.log('MongoDB数据库连接成功')
       return
     } catch (error) {
       retries++


### PR DESCRIPTION
- 调整前

```
MongoDB数据库连接成功
MongoDB连接尝试1失败： Command aggregate requires authentication
MongoDB数据库连接成功
MongoDB连接尝试2失败： Command aggregate requires authentication
MongoDB数据库连接成功
MongoDB连接尝试3失败： Command aggregate requires authentication
MongoDB数据库连接成功
MongoDB连接尝试4失败： Command aggregate requires authentication
MongoDB数据库连接成功
MongoDB连接尝试5失败： Command aggregate requires authentication
在5次尝试后连接到MongoDB失败
```
- 调整后

```
MongoDB连接尝试1失败： Command aggregate requires authentication
MongoDB连接尝试2失败： Command aggregate requires authentication
MongoDB连接尝试3失败： Command aggregate requires authentication
MongoDB连接尝试4失败： Command aggregate requires authentication
MongoDB连接尝试5失败： Command aggregate requires authentication
在5次尝试后连接到MongoDB失败
```

好的，这是将给定的 Pull Request 总结翻译成中文的结果：

## Sourcery 总结

增强：
- 将 'MongoDB数据库连接成功' 日志语句移动到 Config.initialize() 之后，以防止过早的成功日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Move the 'MongoDB数据库连接成功' log statement to after Config.initialize() to prevent premature success logs

</details>