### PR TITLE
Added ContentLength to S3Upload

### DIFF
--- a/server/src/utils/oss.js
+++ b/server/src/utils/oss.js
@@ -171,11 +171,15 @@ export const uploadToS3 = async filePath => {
         '.svg': 'image/svg+xml'
       }[ext] || 'application/octet-stream'
 
+    const stats = await fs.promises.stat(filePath);
+    const contentLength = stats.size;
+
     const command = new PutObjectCommand({
       Bucket: bucket,
       Key: key,
       Body: createReadStream(filePath),
-      ContentType: contentType // 添加 Content-Type
+      ContentType: contentType, // 添加 Content-Type
+      ContentLength: contentLength  
     })
     await s3Client.send(command)
     // 构建访问URL


### PR DESCRIPTION
- fix the https://github.com/setube/stb/issues/17

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 在 `uploadToS3` 中基于文件状态设置 `ContentLength`，以防止缺少内容长度错误 (#17)

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Set ContentLength based on file stats in uploadToS3 to prevent missing content length errors (#17)

</details>