### PR TITLE
fix:s3 upload error

### DIFF
--- a/server/src/utils/oss.js
+++ b/server/src/utils/oss.js
@@ -173,19 +173,44 @@ export const uploadToS3 = async (filePath, Key) => {
       '.webp': 'image/webp',
       '.svg': 'image/svg+xml'
     }
-    const stats = await fs.stat(filePath)
+
+    // 方案1: 尝试直接读取文件内容到 Buffer
+    const fileBuffer = await fs.readFile(filePath)
+
     await s3Client.send(
       new PutObjectCommand({
         Bucket: bucket,
         Key,
-        Body: createReadStream(filePath),
-        ContentType: contentType[ext],
+        Body: fileBuffer,
+        ContentType: contentType[ext] || 'application/octet-stream',
+        ContentLength: fileBuffer.length
+      })
+    )
+
+    return `${endpoint}/${bucket}${Key}`
+
+    /* 
+    // 方案2: 使用流处理
+    const stats = await fs.stat(filePath)
+    const fileStream = createReadStream(filePath)
+    
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key,
+        Body: fileStream,
+        ContentType: contentType[ext] || 'application/octet-stream',
         ContentLength: stats.size
       })
     )
+    
     return `${endpoint}${Key}`
-  } catch ({ message }) {
-    throw new Error(message)
+    */
+
+  } catch (error) {
+    // 改进错误处理，提供更详细的错误信息
+    console.error('S3 上传错误详情:', error)
+    throw new Error(`S3上传失败: ${error.message || error}`)
   }
 }
 


### PR DESCRIPTION
fix #17 #23 

改成直接读取文件内容到 Buffer，避免流处理错误导致`Content-Length`丢失的Bug。
在[我的dev分支](https://github.com/006lp/stb/tree/dev)测试工作正常。

# Todo
- [ ] 添加 S3 代理路由，隐藏真实的 S3 存储地址

> 希望：
> 对外返回的 URL 是 `https://yourdomain.com/s3/s3path/xxxx/xx/xx/xxx.jpg`
> 但实际访问时代理到原来真实的 S3 地址 `https://yourendpoint.com/bucketname/s3img/s3path/xxxx/xx/xx/xxx.jpg`

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

使用缓冲文件上传到 S3，避免 Content-Length 错误，并改进上传错误日志记录

Bug 修复：
- 将 S3 上传从流切换到 Buffer，以确保正确设置 Content-Length

增强功能：
- 记录详细的 S3 上传错误，并抛出描述性的失败消息

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

使用基于 buffer 的方法进行 S3 上传，以确保正确设置 Content-Length 标头并改进错误报告

Bug 修复：
- 将 S3 上传从流式传输切换为将文件读取到 Buffer 中，以修复 Content-Length 缺失问题

增强功能：
- 记录详细的 S3 上传错误并抛出描述性的失败消息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use a buffer-based approach for S3 uploads to ensure the Content-Length header is set correctly and improve error reporting

Bug Fixes:
- Switch S3 upload from stream to reading the file into a Buffer to fix missing Content-Length issue

Enhancements:
- Log detailed S3 upload errors and throw a descriptive failure message

</details>

</details>